### PR TITLE
Filter out excess date information

### DIFF
--- a/app/js/date-ctrl.js
+++ b/app/js/date-ctrl.js
@@ -17,7 +17,13 @@ myApp.filter('unmangle', function() {
     // they'll provide better access to this info?
     var nbsp = input.indexOf("&nbsp");
     var begin = 5;
-    return input.slice(begin,nbsp);
+    var rawdate = input.slice(begin,nbsp);
+    var splitdate = rawdate.split(" ")
+    if (splitdate.length = 11) {
+        var firstpart = splitdate.splice(0,6)
+        var lastpart = splitdate.splice(4,1)
+    }
+    return firstpart.concat(lastpart).join(" ")
   };
 })
 


### PR DESCRIPTION
If the date is normal it is 7 strings separated by spaces, too long and it's 11. When this is the case we only want to keep from index 0 to 6, and index 10. Merge these back into a string with spaces between the words: done, I hope.
